### PR TITLE
removed logging the names of all stripped decorators

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "strip-decorators",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "strip-decorators",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "license": "MIT",
       "bin": {
         "strip-decorators": "dist/bin/main.js"

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -17,7 +17,6 @@ export function compile(program: ts.Program) {
         if (ts.isCallExpression(decorator.expression)) {
           const exp = decorator.expression as ts.CallExpression;
           const decoratorName = exp.expression.getText();
-          console.log(`Found decorator: ${decoratorName}`);
         }
         removedNodes.push(node);
 


### PR DESCRIPTION
This log becomes annoying as the number of decorators increases. Imo this log doesn't have much value besides providing a simple sanity check.

We could alternatively improve logging and make logs optional.